### PR TITLE
Fix tests for templates

### DIFF
--- a/lib/src/util/services/TemplateModelFactory.test.ts
+++ b/lib/src/util/services/TemplateModelFactory.test.ts
@@ -791,6 +791,7 @@ describe("TemplateModelFactory tests", () => {
                     addFunctionalParametersForContextDispatch: false,
                     addGetCurrentStateToContext: false,
                     decoupleStateChangedCallbackByTimeout: false,
+                    verbatimModuleSyntax: true,
                 },
                 reducer: {
                     baseReducerName: undefined,


### PR DESCRIPTION
This pull request makes a minor update to the `TemplateModelFactory` test configuration. The change enables the `verbatimModuleSyntax` flag in the test options, likely to ensure module syntax is handled verbatim during testing.

* Enabled the `verbatimModuleSyntax` option in the `TemplateModelFactory` test configuration.