### PR TITLE
update: upgrade download-artifact action to v4 in workflows

### DIFF
--- a/.github/workflows/buildAndPublishBeta.yml
+++ b/.github/workflows/buildAndPublishBeta.yml
@@ -122,10 +122,9 @@ jobs:
         node-version: ${{ env.nodeVersion }}
 
     - name: Download artifact from build job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       id: downloadArtefact
       with:
-        name: ${{ needs.prepare.outputs.artefactName }}
         path: ${{ env.artefactName }}-${{ needs.prepare.outputs.packageVersion }}-artefact
 
     - name: What has been downloaded

--- a/.github/workflows/buildAndPublishBeta.yml
+++ b/.github/workflows/buildAndPublishBeta.yml
@@ -125,6 +125,7 @@ jobs:
       uses: actions/download-artifact@v4
       id: downloadArtefact
       with:
+        name: ${{ needs.prepare.outputs.artefactName }}
         path: ${{ env.artefactName }}-${{ needs.prepare.outputs.packageVersion }}-artefact
 
     - name: What has been downloaded

--- a/.github/workflows/buildAndPublishProduction.yml
+++ b/.github/workflows/buildAndPublishProduction.yml
@@ -123,10 +123,9 @@ jobs:
         node-version: ${{ env.nodeVersion }}
 
     - name: Download artifact from build job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       id: downloadArtefact
       with:
-        name: ${{ needs.prepare.outputs.artefactName }}
         path: ${{ env.artefactName }}-${{ needs.prepare.outputs.packageVersion }}-artefact
 
     - name: What has been downloaded

--- a/.github/workflows/buildAndPublishProduction.yml
+++ b/.github/workflows/buildAndPublishProduction.yml
@@ -126,6 +126,7 @@ jobs:
       uses: actions/download-artifact@v4
       id: downloadArtefact
       with:
+        name: ${{ needs.prepare.outputs.artefactName }}
         path: ${{ env.artefactName }}-${{ needs.prepare.outputs.packageVersion }}-artefact
 
     - name: What has been downloaded


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a newer version of the `actions/download-artifact` action. The main change is upgrading from version 3 to version 4 in both the beta and production build and publish workflows.

Workflow updates:

* Upgraded `actions/download-artifact` from v3 to v4 in `.github/workflows/buildAndPublishBeta.yml` and `.github/workflows/buildAndPublishProduction.yml` to ensure compatibility with the latest features and improvements. [[1]](diffhunk://#diff-76a2b686b9e5a4c0aa34cc198f228815ef83bbac622959956130894267277681L125-L128) [[2]](diffhunk://#diff-3debe09f029af98e9b904c0da1e1cbfa91152a5a330127ec1ebd801bc9cb68e0L126-L129)